### PR TITLE
Propagate values for Python variables.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,8 @@ else
     fi
 fi
 
+AC_SUBST(PYTHON)
+AC_SUBST(pythondir)
 AC_CONFIG_HEADERS([libpolybori/include/polybori/config.h])
 AC_CONFIG_FILES([
                  Makefile


### PR DESCRIPTION
I added `AC_SUBST` for two variables (a bit of forward thinking) `PYTHON`, the python executable and `pythondir` which is the location of the `site-packages` folder. It seems that missing the latter leads the variable to be filled with unexpected default values by automake.
