### PR TITLE
Force the linking of lib{brial,polybori} with g++

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@ SUBDIRS = Cudd/cudd libbrial . groebner pyroot
 lib_LTLIBRARIES = libbrial.la
 
 libbrial_la_SOURCES =
+# Dummy C++ source to cause C++ linking.
+nodist_EXTRA_libbrial_la_SOURCES = dummy.cxx
 libbrial_la_LIBADD = \
 	Cudd/cudd/libcudd.la \
 	libbrial/src/libbrial_base.la


### PR DESCRIPTION
My firend Steve remarked that `libpolybori` is underlinked with regards to `libstdc++` (and `libm`) in https://github.com/cschwan/sage-on-gentoo/commit/e7385303a5fa7745d9080c47778995cc86322902#commitcomment-12927053

This is because `libpolybori` (now `libbrial` in master) is linked from other convenience libraries and doesn't have any sources showing that it is actually `c++`. In such case libtool uses the `C` compiler by default to link. I just applied the trick described in http://www.gnu.org/software/automake/manual/automake.html#Libtool-Convenience-Libraries to force `C++` linking. That took care of `libm` as well.
