### PR TITLE
Fix sagemath Trac #19643 and #20381

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,11 @@ libbrial_la_SOURCES =
 libbrial_la_LIBADD = \
 	Cudd/cudd/libcudd.la \
 	libbrial/src/libbrial_base.la
+libbrial_la_LDFLAGS = -no-undefined $(AM_LDFLAGS)
 
 EXTRA_DIST = \
 	Cudd/LICENSE \
 	LICENSE \
 	README
+# Dummy C++ source to cause C++ linking.
+nodist_EXTRA_libbrial_la_SOURCES = dummy.cc

--- a/common.mk
+++ b/common.mk
@@ -3,6 +3,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/libbrial/include
 
 AM_CFLAGS = -std=c99
-AM_CXXFLAGS = -std=c++98 -ftemplate-depth-100
+AM_CXXFLAGS = -ftemplate-depth-100
 
 AM_DEFAULT_SOURCE_EXT = .cc

--- a/groebner/src/Makefile.am
+++ b/groebner/src/Makefile.am
@@ -10,6 +10,8 @@ libbrial_groebner_la_LIBADD = \
 	$(M4RI_LIBS) \
 	$(GD_LIBS)
 
+libbrial_groebner_la_LDFLAGS = -no-undefined $(AM_LDFLAGS)
+
 libbrial_groebner_la_SOURCES = \
 	dlex4data.cc \
 	dp_asc4data.cc \


### PR DESCRIPTION
Several small issues with makefiles in brial have come up in sagemath. Instead of keeping the patches in sagemath, it makes more sense to merge them upstream.
