### PR TITLE
Provide comparator to std::map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ autoconf.h*
 /libtool
 /ltmain.sh
 /m4/lt*.m4
+/m4/libtool.m4
 /missing
 stamp-*
 /compile

--- a/libbrial/include/polybori/BooleExponent.h
+++ b/libbrial/include/polybori/BooleExponent.h
@@ -26,6 +26,34 @@
 
 BEGIN_NAMESPACE_PBORI
 
+
+/// Less than comparison (and sortability) of exponents
+template<typename T>
+class MapComparator {
+public:
+  // Auxiliary sort order for exponents as required by std::map
+  //
+  // Implemented as template since we cannot forward declare
+  // BooleExponent::bool_type, but will only be used with T ==
+  // BooleExponent.
+  typename T::bool_type operator()(const T& lhs, const T& rhs) const {
+    typename T::const_iterator li = lhs.begin();
+    typename T::const_iterator ri = rhs.begin();
+    while (true) {
+      if (li == lhs.end())
+        return true;
+      if (ri == rhs.end())
+        return false;
+      if (*li < *ri)
+        return true;
+      li++, ri++;
+    };
+    return false;
+  }
+};
+
+
+
 /** @class BooleExponent
  * @brief This class is just a wrapper for using variables for storing indices
  * as interim data structure for BooleMonomial
@@ -73,7 +101,7 @@ class BooleExponent:
   typedef poly_type::set_type set_type;
 
   /// Type for index maps
-  typedef generate_index_map<self>::type idx_map_type;
+  typedef generate_index_map<self, MapComparator<BooleExponent> >::type idx_map_type;
 
   /// This type has no easy equality check
   typedef invalid_tag easy_equality_property;
@@ -246,6 +274,7 @@ protected:
   /// The actual exponent indices
   data_type m_data;
 };
+
 
 
 /// Multiplication of monomials

--- a/libbrial/include/polybori/routines/pbori_func.h
+++ b/libbrial/include/polybori/routines/pbori_func.h
@@ -623,7 +623,7 @@ public:
   }
 };
 
-template <class Type>
+template <class Type, typename Comparator>
 class generate_index_map {
 
   typedef typename Type::idx_type idx_type;
@@ -637,9 +637,9 @@ public:
      typedef std::unordered_map<Type, idx_type, hashes<Type> > type;
 #  else
 #    ifdef PBORI_HAVE_HASH_MAP
-      typedef __gnu_cxx::hash_map<Type, idx_type, hashes<Type> > type;
+       typedef __gnu_cxx::hash_map<Type, idx_type, hashes<Type> > type;
 #    else
-       typedef std::map<Type, idx_type> type;
+       typedef std::map<Type, idx_type, Comparator> type;
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
I think the case where std::map was used for the index map never was actually valid, its just that you hit that code when you compile with `-std=c++11`. The attached branch supplies an (auxiliary) comparator to make std::map happy.

Fixes #8 
