### PR TITLE
BooleConstant member should not be const

### DIFF
--- a/libbrial/include/polybori/BooleConstant.h
+++ b/libbrial/include/polybori/BooleConstant.h
@@ -101,7 +101,7 @@ public:
 
 protected:
   /// Boolean value is stored as simple bool
-  const bool m_value;
+  bool m_value;
 };
 
 /// Stream output operator


### PR DESCRIPTION
Having a `const` member is just annoying because it forbids a default assignment operator.