### PR TITLE
Make sure tests are properly linked with external libraries.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,7 +39,11 @@ unittests_SOURCES = \
 	unittests.cc
 
 AM_LDFLAGS = $(BOOST_UNIT_TEST_FRAMEWORK_LIB)
-LIBS = $(top_builddir)/groebner/src/libbrial_groebner.la $(top_builddir)/libbrial.la
+LIBS = $(top_builddir)/groebner/src/libbrial_groebner.la \
+	$(top_builddir)/libbrial.la \
+	$(LIBPNG_LIBADD) \
+	$(M4RI_LIBS) \
+	$(GD_LIBS)
 
 check_PROGRAMS = unittests
 


### PR DESCRIPTION
In some libtool configuration library dependencies are not pulled from the build .la file. To make sure the tests are linked properly had the libraries to Makefile.am.