### PR TITLE
replace std::bind2nd by std::bind

### DIFF
--- a/libbrial/include/polybori/routines/pbori_routines_order.h
+++ b/libbrial/include/polybori/routines/pbori_routines_order.h
@@ -459,11 +459,11 @@ block_deg_lex_idx_compare(IdxType lhs, IdxType rhs,
     return CTypes::equality;
 
   Iterator lhsend = std::find_if(start, finish, 
-                                 std::bind2nd(std::greater<IdxType>(), lhs));
+                                 std::bind(std::greater<IdxType>(), std::placeholders::_1, lhs));
 
 
   Iterator rhsend = std::find_if(start, finish, 
-                                 std::bind2nd(std::greater<IdxType>(), rhs));
+                                 std::bind(std::greater<IdxType>(), std::placeholders::_1, rhs));
 
   CTypes::comp_type result = CTypes::equality;
 

--- a/libbrial/src/BooleExponent.cc
+++ b/libbrial/src/BooleExponent.cc
@@ -143,7 +143,7 @@ BooleExponent::insertConst(idx_type idx) const {
   PBORI_TRACE_FUNC( "BooleExponent::insertConst(idx_type) const " );
 
   const_iterator pos =
-    std::find_if(begin(), end(), bind2nd(std::greater_equal<idx_type>(), idx));
+    std::find_if(begin(), end(), std::bind(std::greater_equal<idx_type>(), std::placeholders::_1, idx));
 
   self result;
   result.m_data.resize(size() + 1);
@@ -174,7 +174,7 @@ BooleExponent::insert(idx_type idx) {
 
   iterator pos = 
     std::find_if(internalBegin(), internalEnd(), 
-                 bind2nd(std::greater_equal<idx_type>(), idx));
+                 std::bind(std::greater_equal<idx_type>(), std::placeholders::_1, idx));
 
   if (pos == end())
     m_data.push_back(idx);
@@ -199,7 +199,7 @@ BooleExponent::push_back(idx_type idx) {
     else if (lastIdx > idx) {
       iterator pos = 
         std::find_if(internalBegin(), internalEnd(), 
-                     bind2nd(std::greater_equal<idx_type>(), idx));
+                     std::bind(std::greater_equal<idx_type>(), std::placeholders::_1, idx));
       if (*pos != idx)
         m_data.insert(pos, idx);
     }


### PR DESCRIPTION
std::bind2nd is deprecated in C++11 -- http://en.cppreference.com/w/cpp/utility/functional/bind12 . The new std::bind is now used as a replacement.