### PR TITLE
Use std::shared_ptr instead of boost::shared_ptr

### DIFF
--- a/groebner/include/polybori/groebner/GroebnerStrategy.h
+++ b/groebner/include/polybori/groebner/GroebnerStrategy.h
@@ -27,7 +27,7 @@
 #include "GroebnerOptions.h"
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <polybori/routines/pbori_algo.h> // member-for_each etc.
 
@@ -202,7 +202,7 @@ private:
 public:
   /// @name public available parameters
   ReductionStrategy generators;
-  boost::shared_ptr<CacheManager> cache;
+  std::shared_ptr<CacheManager> cache;
 
   unsigned int reductionSteps;
   int normalForms;

--- a/groebner/include/polybori/groebner/LexBucket.h
+++ b/groebner/include/polybori/groebner/LexBucket.h
@@ -10,7 +10,7 @@
 #include "groebner_defs.h"
 
 #include "LiteralFactorization.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <queue>
 #include <algorithm>
 #include <utility>

--- a/groebner/include/polybori/groebner/PairLS.h
+++ b/groebner/include/polybori/groebner/PairLS.h
@@ -18,11 +18,11 @@
 
 // include basic definitions
 #include "groebner_defs.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 BEGIN_NAMESPACE_PBORIGB
 
-typedef boost::shared_ptr<PairData> pair_data_ptr;
+typedef std::shared_ptr<PairData> pair_data_ptr;
 
 enum {
   VARIABLE_PAIR,

--- a/groebner/include/polybori/groebner/cache_manager.h
+++ b/groebner/include/polybori/groebner/cache_manager.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <utility>
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "groebner_defs.h"
 #ifndef PBORI_GB_CACHE_H
 #define PBORI_GB_CACHE_H
@@ -30,7 +30,7 @@ class CacheManager{
         typedef Polynomial::poly_vec_map_type impl_type;
         
         typedef std::vector<Polynomial> poly_vec_type;
-        typedef boost::shared_ptr<poly_vec_type> res_type;
+        typedef std::shared_ptr<poly_vec_type> res_type;
         typedef Polynomial::poly_vec_map_type::const_iterator impl_iterator_type;
     protected:
         impl_type impl;

--- a/groebner/include/polybori/groebner/pairs.h
+++ b/groebner/include/polybori/groebner/pairs.h
@@ -23,7 +23,7 @@
 #include <functional>
 #include "groebner_defs.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <queue>
 #include <algorithm>
 #include <utility>

--- a/libbrial/include/polybori/common/CWeakPtr.h
+++ b/libbrial/include/polybori/common/CWeakPtr.h
@@ -36,7 +36,7 @@ public:
   typedef ValueType value_type;
 
   typedef value_type* data_type;
-  typedef boost::shared_ptr<data_type> ptr_type;
+  typedef std::shared_ptr<data_type> ptr_type;
 
 
   /// Construct from something, which supports weak pointers

--- a/libbrial/include/polybori/common/CWeakPtrFacade.h
+++ b/libbrial/include/polybori/common/CWeakPtrFacade.h
@@ -18,7 +18,7 @@
 
 // include basic definitions
 #include <polybori/pbori_defs.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 BEGIN_NAMESPACE_PBORI
@@ -40,7 +40,7 @@ class CWeakPtrFacade {
 public:
   typedef ValueType value_type;
   typedef value_type* data_type;
-  typedef boost::shared_ptr<data_type> ptr_type;
+  typedef std::shared_ptr<data_type> ptr_type;
 
   friend class CWeakPtr<value_type>;
 

--- a/libbrial/include/polybori/iterators/COrderedIter.h
+++ b/libbrial/include/polybori/iterators/COrderedIter.h
@@ -37,7 +37,7 @@ public:
 
   typedef CAbstractStackBase<NavigatorType> self;
   typedef CTermStackBase<NavigatorType, self> iterator_core;
-  typedef boost::shared_ptr<iterator_core> core_pointer;
+  typedef std::shared_ptr<iterator_core> core_pointer;
 
   virtual void increment() = 0;
   virtual core_pointer copy() const = 0;
@@ -57,7 +57,7 @@ public:
   typedef typename base::navigator navigator;
 
   typedef typename base::iterator_core iterator_core;
-  typedef boost::shared_ptr<iterator_core> core_pointer;
+  typedef std::shared_ptr<iterator_core> core_pointer;
 
   template <class MgrType>
   CWrappedStack(navigator navi, const MgrType& mgr):
@@ -136,7 +136,7 @@ public:
   typedef NavigatorType navigator;
  
   // Store shared pointer of iterator
-  typedef boost::shared_ptr<iterator_core> core_pointer;
+  typedef std::shared_ptr<iterator_core> core_pointer;
 
   /// Extract plain Boolean type
   typedef bool bool_type;

--- a/libbrial/include/polybori/orderings/pbori_order.h
+++ b/libbrial/include/polybori/orderings/pbori_order.h
@@ -30,9 +30,9 @@
 
 BEGIN_NAMESPACE_PBORI
 
-inline boost::shared_ptr<COrderingBase>
+inline std::shared_ptr<COrderingBase>
 get_ordering(CTypes::ordercode_type order) {
-  typedef boost::shared_ptr<COrderingBase> order_ptr;
+  typedef std::shared_ptr<COrderingBase> order_ptr;
 
   if(order == CTypes::lp)
     return order_ptr(new LexOrder);

--- a/libbrial/include/polybori/ring/CCuddCore.h
+++ b/libbrial/include/polybori/ring/CCuddCore.h
@@ -30,7 +30,7 @@
 #include <boost/intrusive_ptr.hpp>
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 BEGIN_NAMESPACE_PBORI
 
@@ -69,7 +69,7 @@ public:
   typedef COrderingBase order_type;
   
   /// Smart pointer for handling mterm orderings
-  typedef boost::shared_ptr<order_type> order_ptr;
+  typedef std::shared_ptr<order_type> order_ptr;
 
   /// Reference for handling mterm orderings
   typedef order_type& order_reference;


### PR DESCRIPTION
Since BRiAl is now compiled with --std=c++11, the dependence on boost::shared_ptr should be removed and is replaced by std::shared_ptr.