### PR TITLE
Fix unitialized iterators

### DIFF
--- a/libbrial/include/polybori/orderings/COrderingBase.h
+++ b/libbrial/include/polybori/orderings/COrderingBase.h
@@ -46,6 +46,9 @@ class COrderingBase:
   /// Type of *this
   typedef COrderingBase self;
 
+  // an empty vector to be able to return valid iterators in the implementation of blockBegin()/blockEnd()
+  static const std::vector<idx_type> empty;
+
 public:
   /// @name Adopt polynomial type definitions
   //@{
@@ -145,8 +148,8 @@ public:
 
   /// @name interface for block orderings
   //@{
-  virtual block_iterator blockBegin() const { return block_iterator(); }
-  virtual block_iterator blockEnd() const { return block_iterator(); }
+  virtual block_iterator blockBegin() const { return empty.begin(); }
+  virtual block_iterator blockEnd() const { return empty.end(); }
   virtual void appendBlock(checked_idx_type) {}
   virtual void clearBlocks() {}
   //@}

--- a/libbrial/src/COrderingBase.cc
+++ b/libbrial/src/COrderingBase.cc
@@ -1,0 +1,21 @@
+// -*- c++ -*-
+//*****************************************************************************
+/** @file COrderingBase.cc
+ *
+ * @author Julian Rüth
+ * @date 2018-03-11
+ *
+ * Initializes the members of COrderingBase. 
+ *
+ * @par Copyright:
+ *   (c) 2018 Julian Rüth
+**/
+//*****************************************************************************
+
+#include <polybori/orderings/COrderingBase.h>
+
+BEGIN_NAMESPACE_PBORI
+
+const std::vector<int> COrderingBase::empty;
+
+END_NAMESPACE_PBORI

--- a/libbrial/src/DegLexOrder.cc
+++ b/libbrial/src/DegLexOrder.cc
@@ -31,8 +31,6 @@
 
 BEGIN_NAMESPACE_PBORI
 
-
-
 // Comparison of monomials
 DegLexOrder::comp_type
 DegLexOrder::compare(const monom_type& lhs, const monom_type& rhs) const {

--- a/libbrial/src/Makefile.am
+++ b/libbrial/src/Makefile.am
@@ -16,6 +16,7 @@ libbrial_base_la_SOURCES = \
 	CCuddFirstIter.cc \
 	CCuddLastIter.cc \
 	CErrorInfo.cc \
+	COrderingBase.cc \
 	DegLexOrder.cc \
 	DegRevLexAscOrder.cc \
 	LexOrder.cc \

--- a/tests/DegLexOrderTest.cc
+++ b/tests/DegLexOrderTest.cc
@@ -20,9 +20,6 @@ using boost::test_tools::output_test_stream;
 
 #include <polybori/DegLexOrder.h>
 
-// make sure we can find _LIBCPP_VERSION if it exists
-#include <ciso646>
-
 USING_NAMESPACE_PBORI
 
 class Fdeglex {
@@ -224,10 +221,7 @@ BOOST_AUTO_TEST_CASE(test_blocks) {
   order.clearBlocks();
   start = order.blockBegin();
   finish = order.blockEnd();
-// This test fails with clang's libcxx
-#ifndef _LIBCPP_VERSION
   BOOST_CHECK(start==finish);
-#endif
 }
 
 

--- a/tests/DegRevLexAscOrderTest.cc
+++ b/tests/DegRevLexAscOrderTest.cc
@@ -20,9 +20,6 @@ using boost::test_tools::output_test_stream;
 
 #include <polybori/DegRevLexAscOrder.h>
 
-// make sure we can find _LIBCPP_VERSION if it exists
-#include <ciso646>
-
 USING_NAMESPACE_PBORI
 
 struct Fdegrevlex {
@@ -194,10 +191,7 @@ BOOST_AUTO_TEST_CASE(test_blocks) {
   order.clearBlocks();
   start = order.blockBegin();
   finish = order.blockEnd();
-// This test fails with clang's libcxx
-#ifndef _LIBCPP_VERSION
   BOOST_CHECK(start==finish);
-#endif
 }
 
 

--- a/tests/LexOrderTest.cc
+++ b/tests/LexOrderTest.cc
@@ -20,9 +20,6 @@ using boost::test_tools::output_test_stream;
 
 #include <polybori/LexOrder.h>
 
-// make sure we can find _LIBCPP_VERSION if it exists
-#include <ciso646>
-
 USING_NAMESPACE_PBORI
 
 
@@ -150,20 +147,14 @@ BOOST_AUTO_TEST_CASE(test_blocks) {
   output_test_stream output;
   BoolePolyRing::block_iterator start(order.blockBegin()),finish(order.blockEnd());
 
-// This test fails with clang's libcxx
-#ifndef _LIBCPP_VERSION
   BOOST_CHECK(start == finish);
-#endif
   BOOST_CHECK_THROW(order.appendBlock(-1), std::exception);
   order.appendBlock(0);
   order.appendBlock(2);
   order.appendBlock(6);
   start = order.blockBegin();
   finish = order.blockEnd();
-// This test fails with clang's libcxx
-#ifndef _LIBCPP_VERSION
   BOOST_CHECK(start == finish);
-#endif
   
   BOOST_CHECK(order.lieInSameBlock(0,1));
   BOOST_CHECK(order.lieInSameBlock(-1,4));
@@ -171,10 +162,7 @@ BOOST_AUTO_TEST_CASE(test_blocks) {
   order.clearBlocks();
   start = order.blockBegin();
   finish = order.blockEnd();
-// This test fails with clang's libcxx
-#ifndef _LIBCPP_VERSION
   BOOST_CHECK(start==finish);
-#endif
 }
 
 


### PR DESCRIPTION
I did not really know where to put the initializer of the empty vector so I put
it in its own file. I hope that's alright.