### PR TITLE
Remove use of deprecated imp module

### DIFF
--- a/sage-brial/brial/gbrefs.py
+++ b/sage-brial/brial/gbrefs.py
@@ -6,7 +6,7 @@ except ImportError:
     from io import StringIO
 import uu
 import re
-import imp
+from types import ModuleType
 from .PyPolyBoRi import *
 AUTO = "auto"
 SINGLE = "single"
@@ -118,7 +118,7 @@ def my_import(name, globals=None, locals=None):
 
 
 def dyn_generate(content, name):
-    module = imp.new_module(name)
+    module = ModuleType(name)
     import_header = """from .PyPolyBoRi import Variable,Monomial, Polynomial, Ring, OrderCode
 from itertools import chain
 from .blocks import AlternatingBlock,Block,AdderBlock,if_then,HigherOrderBlock,declare_ring as orig_declare_ring,declare_block_scheme,MacroBlock\n


### PR DESCRIPTION
`imp` has been deprecated since python 3.4. The documentation[1]
suggests to use the `ModuleType` constructor instead, which is what I'm
doing here.

The use of the deprecated `imp` module caused a deperecation warning,
which then caused a doctest failure in sage on nixos. Not sure why it
apparently wasn't an issue with the python3 swich on
sage-the-distribution.

[1] https://docs.python.org/3.5/library/imp.html#imp.new_module