### PR TITLE
take M4RI CFLAGS into account

### DIFF
--- a/groebner/src/Makefile.am
+++ b/groebner/src/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/common.mk
 
 lib_LTLIBRARIES = libbrial_groebner.la
 
-libbrial_groebner_la_CXXFLAGS = $(AM_CXXFLAGS) $(SIMMD_CFLAGS)
+libbrial_groebner_la_CXXFLAGS = $(AM_CXXFLAGS) $(M4RI_CFLAGS) $(SIMMD_CFLAGS)
 
 libbrial_groebner_la_LIBADD = \
 	$(top_builddir)/libbrial.la \


### PR DESCRIPTION
This is required if M4RI is built in a non-standard location (otherwise m4ri.h is not found)