### PR TITLE
build: copy brial.pc on `make install`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = cudd libbrial . groebner tests
 
 lib_LTLIBRARIES = libbrial.la
+pkgconfig_DATA = brial.pc
 
 libbrial_la_SOURCES =
 libbrial_la_LIBADD = \
@@ -17,3 +18,5 @@ EXTRA_DIST = \
 
 # Dummy C++ source to cause C++ linking.
 nodist_EXTRA_libbrial_la_SOURCES = dummy.cc
+
+brial.pc: ${top_builddir}/config.status

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,10 @@ AC_ARG_ENABLE([debug],
               [AS_HELP_STRING([--enable-debug],
                               [enable extra debugging statements in BRiAl's code [default=no]])],
               [AC_DEFINE([PBORI_DEBUG],[],[enable extra debugging statements])])
+AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
+	[Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
+	[pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
+AC_SUBST([pkgconfigdir])
 
 dnl version constraint to prevent broken pkg-config file from m4ri
 PKG_CHECK_MODULES([M4RI], [m4ri >= 20250128], [AC_DEFINE([PBORI_HAVE_M4RI],[],[has m4ri])])


### PR DESCRIPTION
brial.pc is pretty useless when it's not installed.

Fixes bug introduced by: https://github.com/BRiAl/BRiAl/issues/57