### PR TITLE
export CFLAGS of m4ri, use them in tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,8 @@ AX_M4RI_CFLAGS()
 SIMMD_CFLAGS=$ax_cv_m4ri_cflags
 AC_SUBST(SIMMD_CFLAGS)
 
+M4RI_CFLAGS=$pkg_cv_M4RI_CFLAGS
+AC_SUBST(M4RI_CFLAGS)
 
 if test "x$m4ri_png" = "xyes"; then
     PKG_CHECK_MODULES([PNG], [libpng],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,6 @@
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
+	$(M4RI_CFLAGS) \
 	-I$(top_srcdir)/groebner/include \
 	-I$(top_builddir)/libbrial/include \
 	-I$(top_srcdir)/libbrial/include \


### PR DESCRIPTION
get cflags of m4ri exported into M4RI_CFLAGS, and use it in the tests Makefile